### PR TITLE
Scale Tracking Circles like rest of icons

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -489,8 +489,8 @@ function Display:addMiniPin(pin, refresh)
 		pin.texture:SetTexture(trackingCircle)
 		local t = db.trackColors[pin.nodeType]
 		pin.texture:SetVertexColor(t.Red, t.Green, t.Blue, t.Alpha)
-		pin:SetHeight(12 / minimapScale)
-		pin:SetWidth(12 / minimapScale)
+		pin:SetHeight(12 * db.miniscale / minimapScale)
+		pin:SetWidth(12 * db.miniscale / minimapScale)
 		pin.isCircle = true
 		pin.texture:SetTexCoord(0, 1, 0, 1)
 		pin.texture:ClearAllPoints()


### PR DESCRIPTION
Hello,

I have added this very simple change that makes the tracking circles scale like the rest of icons. I recently increased the size of my MiniMap, which resulted in larger nodes shown by tracking. I increased the scale of the icons in GatherMate2 settings, but it didn't affect the scale of tracking circles. Because of this, the tracking circles didn't really fit well any more, at least in my opinion, and making them follow the scale of the icons sounded like a good idea.

Pictures below show before and after the change. I think it would be a good addition to the addon. :)

<img width="318" height="332" alt="image" src="https://github.com/user-attachments/assets/576774d1-5754-4942-913f-779cb0661d1c" />
<img width="318" height="342" alt="image" src="https://github.com/user-attachments/assets/1209f2ba-acf9-4219-b500-aace98fe8208" />
