### PR TITLE
fix: Clamp SetAlpha alpha to valid 0-1 range

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -538,7 +538,7 @@ function Display:addMiniPin(pin, refresh)
 		pin:Show()
 		pin:ClearAllPoints()
 		pin:SetPoint("CENTER", Minimap, "CENTER", diffX * minimapWidth, -diffY * minimapHeight)
-		pin:SetAlpha(min(alpha,db.alpha))
+		pin:SetAlpha(max(0, min(alpha, db.alpha)))
 	else
 		pin:Hide()
 	end


### PR DESCRIPTION
Single-commit fix — apologies for the messy PR earlier.

## Problem

When a minimap pin is at the edge of tracking range, floating point arithmetic in `addMiniPin` can produce a slightly negative `alpha` value (e.g. `-0.000743`), causing:

```
Display.lua:527: bad argument #1 to 'SetAlpha' (Usage: self:SetAlpha(alpha))
```

In active farming sessions this generates 600+ errors.

## Fix

```lua
-- Before
pin:SetAlpha(min(alpha, db.alpha))

-- After  
pin:SetAlpha(max(0, min(alpha, db.alpha)))
```

One-line change, no behavior impact for pins within normal range.