### PR TITLE
Update storage TOCs for WoW 12.1.0

### DIFF
--- a/Storage/Dragonflight/GatherMate2Storage_Dragonflight.toc
+++ b/Storage/Dragonflight/GatherMate2Storage_Dragonflight.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120007,120100
 ## Title: GatherMate2: Storage for Dragonflight
 ## Author: nevcairiel
 ## Group: GatherMate2

--- a/Storage/Midnight/GatherMate2Storage_Midnight.toc
+++ b/Storage/Midnight/GatherMate2Storage_Midnight.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120007,120100
 ## Title: GatherMate2: Storage for Midnight
 ## Author: nevcairiel
 ## Group: GatherMate2

--- a/Storage/TheWarWithin/GatherMate2Storage_TheWarWithin.toc
+++ b/Storage/TheWarWithin/GatherMate2Storage_TheWarWithin.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120007,120100
 ## Title: GatherMate2: Storage for The War Within
 ## Author: nevcairiel
 ## Group: GatherMate2


### PR DESCRIPTION
## What changed

Updated the Interface metadata in all three expansion storage addons to match the main GatherMate2 addon:

- Dragonflight storage
- The War Within storage
- Midnight storage

Each now declares compatibility with 12.0.7 and 12.1.0.

## Why

The main addon was updated for WoW 12.1.0 in b454567, but its separately packaged storage addon TOCs remained at 12.0.1. WoW therefore flags those companion modules as out of date even though their shared storage loader requires no API changes.

## Impact

The storage modules will no longer be reported as out of date on WoW 12.1.0. Saved-variable names, zone assignments, and storage behavior are unchanged.

## Validation

- Confirmed every storage TOC Interface line exactly matches GatherMate2.toc
- Confirmed the package metadata still moves each storage directory into its companion addon
- Ran git diff --check