### PR TITLE
Add separate minimap icon alpha setting

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -260,11 +260,19 @@ local minimapOptions = {
 		},
 		iconAlpha = {
 			order = 12,
-			name = L["Icon Alpha"],
+			name = L["World Map Icon Alpha"],
 			desc = L["Icon alpha value, this lets you change the transparency of the icons. Only applies on World Map."],
 			type = "range",
 			min = 0.1, max = 1, step = 0.05,
 			arg = "alpha",
+		},
+		miconAlpha = {
+			order = 13,
+			name = L["Minimap Icon Alpha"],
+			desc = L["Icon alpha value, this lets you change the transparency of the icons. Only applies on Minimap."],
+			type = "range",
+			min = 0.1, max = 1, step = 0.05,
+			arg = "minimapAlpha",
 		},
 		tracking = {
 			order = 20,

--- a/Display.lua
+++ b/Display.lua
@@ -554,7 +554,7 @@ function Display:addMiniPin(pin, refresh)
 		pin:Show()
 		pin:ClearAllPoints()
 		pin:SetPoint("CENTER", Minimap, "CENTER", diffX * minimapWidth, -diffY * minimapHeight)
-		pin:SetAlpha(min(alpha,db.alpha))
+		pin:SetAlpha(min(alpha,db.minimapAlpha))
 	else
 		pin:Hide()
 	end

--- a/GatherMate2.lua
+++ b/GatherMate2.lua
@@ -20,6 +20,7 @@ local defaults = {
 		scale       = 1.0,
 		miniscale	= 0.75,
 		alpha       = 1,
+		minimapAlpha = 1,
 		show = {
 			["Treasure"] = "always",
 			["Logging"]  = "active",


### PR DESCRIPTION
This adds independent alpha controls for world-map and minimap node icons.

Previously, the existing world-map alpha setting was also applied to minimap pins. This made it difficult to reduce the opacity of GatherMate2’s minimap tracking circles without also fading icons on the world map.

Changes:
- Add a separately saved `minimapAlpha` preference.
- Add distinct “World Map Icon Alpha” and “Minimap Icon Alpha” controls.
- Apply `minimapAlpha` only to minimap pins.
- Preserve the existing `alpha` preference for world-map icons, maintaining backward compatibility.

This makes active gathering-node blips easier to distinguish from GatherMate2’s nearby spawn indicators.